### PR TITLE
fix: Twitterのリンク切れを修正

### DIFF
--- a/help.html
+++ b/help.html
@@ -115,7 +115,7 @@
                             target="_blank">導入URL</a>
                     </div>
                     <div>
-                        <a href="https://twitter.com/RT85834744" target="_blank">Twitter</a>
+                        <a href="https://twitter.com/RtDiscordBot" target="_blank">Twitter</a>
                     </div>
                     <div>
                         <a href="https://github.com/RT-Team" target="_blank">GitHub</a>

--- a/layout.html
+++ b/layout.html
@@ -98,7 +98,7 @@
                                 target="_blank">導入URL</a>
                         </div>
                         <div>
-                            <a href="https://twitter.com/RT85834744" target="_blank">Twitter</a>
+                            <a href="https://twitter.com/RtDiscordBot" target="_blank">Twitter</a>
                         </div>
                         <div>
                             <a href="https://github.com/RT-Team" target="_blank">GitHub</a>


### PR DESCRIPTION
- 変更点
RTのTwitterへのリンクが[@RT85834744](https://twitter.com/RT85834744)になっていたのを、[@RtDiscordBot](https://twitter.com/RtDiscordBot)へと変更しました。

<h6>(Gitの使い方含めて)初心者です～無駄なプルリクだったら大目に見てください～</h6>