### PR TITLE
fix : ログインページにリダイレクトされないバグの修正

### DIFF
--- a/dashboard/utils.js
+++ b/dashboard/utils.js
@@ -6,7 +6,7 @@
  */
 function requireLogin() {
     alert("ログインをしてください。");
-    window.location = "https://rt-bot.com/api/account/login";
+    window.location = "../api/account/login";
 };
 
 


### PR DESCRIPTION
プル失礼します。以前プルさせていただいた時の、ダッシュボードからログインページに直接リダイレクトするというものが正しく行われていなかったので新たにプルリクエストをしました。
リンクだったのをディレクトリの階層指定で行うようにしただけです。